### PR TITLE
Added `auth=true` to onboarding-panel url.

### DIFF
--- a/functions/atlassian-connect.json
+++ b/functions/atlassian-connect.json
@@ -375,7 +375,7 @@
     },
     "webPanels": [
       {
-        "url": "/onboarding-panel.html?version=__VERSION__&addonKey=__ADDON_KEY__&postInstallPageKey=__POST_INSTALL_KEY__",
+        "url": "/onboarding-panel.html?auth=true&version=__VERSION__&addonKey=__ADDON_KEY__&postInstallPageKey=__POST_INSTALL_KEY__",
         "location": "atl.footer",
         "layout": {
           "width": "0px",


### PR DESCRIPTION
This is used to monitor if when all clients are migrated the new descriptor. Clients using old descriptor will not have auth=true in the URL.