### PR TITLE
Updated descriptor version to 2023.06.

### DIFF
--- a/functions/descriptor.js
+++ b/functions/descriptor.js
@@ -1,7 +1,7 @@
 const descriptor = require('./atlassian-connect.json');
 const liteKeySuffix = '-lite';
 const liteNameSuffix = ' Lite';
-const VERSION = '2022.07';
+const VERSION = '2023.06';
 
 export const onRequestGet = async (params) => {
   const req = params.request;


### PR DESCRIPTION
This will trigger re-installation. This gives us three benefits:
1. Identify all clients on mixpanel.
2. If there is any issue, we can address it early.
3. We can remove sentry.io later.