### PR TITLE
fix: set generic-viewer to full-width 

### DIFF
--- a/public/sequence-viewer-dialog.html
+++ b/public/sequence-viewer-dialog.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <!--Use style width:fit-content before tailwind builds it in.-->
-<div class="mx-auto" style="width: fit-content">
+<div class="mx-auto" style="width: 100%">
   <div id="app"></div>
 </div>
 <!-- built files will be auto injected -->

--- a/public/sequence-viewer.html
+++ b/public/sequence-viewer.html
@@ -16,7 +16,7 @@
 
 </head>
 <body>
-<div class="mx-auto" style="width: fit-content">
+<div class="mx-auto" style="width: 100%">
   <div id="app"></div>
 </div>
 <!-- built files will be auto injected -->

--- a/src/components/Mermaid.vue
+++ b/src/components/Mermaid.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-html="svg"></div>
+    <div class="flex justify-center" v-html="svg"></div>
   </div>
 </template>
 

--- a/src/components/Viewer/GenericViewer.vue
+++ b/src/components/Viewer/GenericViewer.vue
@@ -33,7 +33,7 @@
         </div>
       </div>
       <div class="flex justify-center screen-capture-content">
-        <div class="mr-8" :class="{'w-full': wide}">
+        <div :class="{'w-full': wide, 'mr-8': !wide}">
           <slot></slot>
         </div>
       </div>


### PR DESCRIPTION
Set the container of sequence-viewer and sequence-viewer-dialog to full with.
Center the mermaid svg graph.