### PR TITLE
Add image width in attachment.ts

### DIFF
--- a/functions/attachment.ts
+++ b/functions/attachment.ts
@@ -2,7 +2,7 @@ export const onRequestGet: PagesFunction = async (params: any) => {
   const { searchParams } = new URL(params.request.url);
   const uuid = searchParams.get('uuid');
 	return new Response(
-		`<ac:image> <ri:attachment ri:filename="zenuml-${uuid}.png" /> </ac:image>`,
+		`<ac:image ac:width="950"> <ri:attachment ri:filename="zenuml-${uuid}.png" /> </ac:image>`,
 		{}
 	);
 };


### PR DESCRIPTION
After many trials and errors, I set the image width to `950px`, which displays all the diagrams fully while extending almost the full width of the page.