### PR TITLE
feat: optimize graph title

### DIFF
--- a/src/components/DrawIoExtension/DrawIoExtension.vue
+++ b/src/components/DrawIoExtension/DrawIoExtension.vue
@@ -37,6 +37,7 @@ export default defineComponent({
     };
     onMounted(() => {
       if (props.doc?.id) {
+        if (!props.doc.title) return
         title.value = props.doc.title;
       } else {
         modalVisible.value = true;

--- a/src/components/DrawIoExtension/components/DrawIoHeader.vue
+++ b/src/components/DrawIoExtension/components/DrawIoHeader.vue
@@ -1,26 +1,31 @@
 <template>
-  <div class="absolute h-8 w-[100vw] bg-[#f1f3f4] pl-[10px] py-1">
-    <div class="text-lg cursor-pointer" @click="handleEditTitle">
-      {{ title }}
+  <div class="absolute flex h-8 w-[100vw] bg-[#f1f3f4] pl-[10px] py-1">
+    <div class="flex items-center text-lg cursor-pointer" @click="handleEditTitle">
+      <div>{{ title }}</div>
+      <IconEdit class="text-gray-600 pl-1"  />
     </div>
   </div>
 </template>
 
 <script>
 import { defineComponent } from "vue";
+import IconEdit from "@/components/icons/IconEdit.vue";
 
 export default defineComponent({
+  components: {
+    IconEdit,
+  },
   props: {
     title: {
       type: String,
-      default: ""
-    }
+      default: "",
+    },
   },
   methods: {
     handleEditTitle() {
       this.$emit("editTitle");
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/src/components/icons/IconEdit.vue
+++ b/src/components/icons/IconEdit.vue
@@ -1,0 +1,41 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="props.width || 24"
+    :height="props.height || 24"
+    viewBox="0 0 24 24"
+    stroke-width="2"
+    stroke="currentColor"
+    fill="none"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" />
+    <path
+      d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z"
+    />
+    <path d="M16 5l3 3" />
+  </svg>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "IconEdit",
+  props: {
+    width: {
+      type: String,
+      default: "24"
+    },
+    height: {
+      type: String,
+      default: "24"
+    },
+  },
+  setup(props) {
+    return {props};
+  }
+});
+</script>


### PR DESCRIPTION
- display "Untitled" as default graph title
- add an edit icon behind the title

![image](https://github.com/ZenUml/confluence-plugin-cloud/assets/32098252/95ea6485-08f8-476e-a8ce-337749a6b09f)

